### PR TITLE
Remove upper bound for python dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 N4 = "flake8_broken_line:check_line_breaks"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = ">=3.7"
 
 flake8 = ">=3.5,<6"
 importlib-metadata = { version = "*", python = "<3.8" }


### PR DESCRIPTION
Currently this project declares that it is not compatible with python `>=4.0`, this sounds reasonable in that
"python 4.0" is kind of an abstract concept, but has the unfortunate side effect that any projects that do not make the same declaration cannot depend on flake8-broken-line, or any other project that depends on it!

This post elaborates better than I can on why it is a better practice to only set a lower bound for python compatibility in almost all cases: https://iscinumpy.dev/post/bound-version-constraints/

This change is required as a prerequisite of a similar change [here](https://github.com/rstcheck/rstcheck/issues/171), which in turn is required before I can upgrade rstcheck to a recent version [here](https://github.com/nat-n/poethepoet/blob/86db3830469f1da1a5951575050d9ea8250887ea/pyproject.toml#L28).